### PR TITLE
Add simple MT5 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# metatrader5-mcp-server
+# MetaTrader5 MCP Server
+
+This repository provides a minimal template for building a MetaTrader 5 MCP server using Python and Flask. It demonstrates how to connect to a local MetaTrader 5 terminal and execute basic operations through simple REST APIs.
+
+## Requirements
+
+- Python 3.12 or later
+- Dependencies listed in `requirements.txt`
+- A running MetaTrader 5 terminal (the `MetaTrader5` Python package must be installed separately)
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+python -m mcp_server.server
+```
+
+## Endpoints
+
+- `GET /api/v1/ping` – health check endpoint.
+- `POST /api/v1/connect` – initialize connection to MetaTrader 5.
+- `GET /api/v1/account` – fetch account information.
+- `POST /api/v1/orders` – send a market order using connected terminal.
+
+Feel free to extend these handlers with your own logic or build on top of the `MT5Client` class provided in `mcp_server.mt5_client`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository provides a minimal template for building a MetaTrader 5 MCP serv
 
 - Python 3.12 or later
 - Dependencies listed in `requirements.txt`
-- A running MetaTrader 5 terminal (the `MetaTrader5` Python package must be installed separately)
+- A running MetaTrader 5 terminal
 
 ## Setup
 

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,0 +1,5 @@
+"""Template server and utilities for MetaTrader5 integration."""
+
+from .mt5_client import MT5Client
+
+__all__ = ["MT5Client"]

--- a/mcp_server/mt5_client.py
+++ b/mcp_server/mt5_client.py
@@ -1,0 +1,48 @@
+import MetaTrader5 as mt5
+from typing import Optional, List, Dict
+
+class MT5Client:
+    """Simple wrapper around the MetaTrader5 package."""
+
+    def __init__(self, login: int, password: str, server: str) -> None:
+        self.login = login
+        self.password = password
+        self.server = server
+
+    def connect(self) -> bool:
+        """Initialize connection with provided credentials."""
+        return mt5.initialize(login=self.login, password=self.password, server=self.server)
+
+    def shutdown(self) -> None:
+        """Close connection to MetaTrader5 terminal."""
+        mt5.shutdown()
+
+    def is_connected(self) -> bool:
+        """Check if connection to MetaTrader5 terminal is active."""
+        return mt5.terminal_info() is not None
+
+    def account_info(self) -> Optional[Dict]:
+        info = mt5.account_info()
+        return info._asdict() if info else None
+
+    def positions(self) -> List[Dict]:
+        positions = mt5.positions_get()
+        return [p._asdict() for p in positions] if positions else []
+
+    def get_rates(self, symbol: str, timeframe: int, start_pos: int, count: int) -> List[Dict]:
+        """Retrieve historical rates from the terminal."""
+        rates = mt5.copy_rates_from_pos(symbol, timeframe, start_pos, count)
+        return [r._asdict() for r in rates] if rates is not None else []
+
+    def send_market_order(self, symbol: str, volume: float, order_type: int, comment: str = "") -> Optional[Dict]:
+        request = {
+            "action": mt5.TRADE_ACTION_DEAL,
+            "symbol": symbol,
+            "volume": volume,
+            "type": order_type,
+            "comment": comment,
+            "type_time": mt5.ORDER_TIME_GTC,
+            "type_filling": mt5.ORDER_FILLING_IOC,
+        }
+        result = mt5.order_send(request)
+        return result._asdict() if result else None

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,55 @@
+from flask import Flask, request, jsonify
+
+from .mt5_client import MT5Client
+
+client: MT5Client | None = None
+
+app = Flask(__name__)
+
+@app.route("/api/v1/ping", methods=["GET"])
+def ping():
+    return jsonify({"message": "pong"})
+
+
+@app.route("/api/v1/connect", methods=["POST"])
+def connect():
+    """Initialize connection to MetaTrader 5 terminal."""
+    global client
+    data = request.get_json() or {}
+    login = data.get("login")
+    password = data.get("password")
+    server = data.get("server")
+    if not (login and password and server):
+        return jsonify({"error": "login, password and server are required"}), 400
+
+    client = MT5Client(int(login), password, server)
+    if not client.connect():
+        return jsonify({"error": "failed to connect"}), 500
+    return jsonify({"status": "connected"})
+
+
+@app.route("/api/v1/account", methods=["GET"])
+def account():
+    """Return account information from connected terminal."""
+    if not client or not client.is_connected():
+        return jsonify({"error": "not connected"}), 400
+    info = client.account_info()
+    return jsonify(info)
+
+@app.route("/api/v1/orders", methods=["POST"])
+def place_order():
+    if not client or not client.is_connected():
+        return jsonify({"error": "not connected"}), 400
+    payload = request.get_json() or {}
+    symbol = payload.get("symbol")
+    volume = payload.get("volume")
+    order_type = payload.get("type")
+    comment = payload.get("comment", "")
+    if not (symbol and volume and order_type is not None):
+        return jsonify({"error": "symbol, volume and type are required"}), 400
+
+    result = client.send_market_order(symbol, float(volume), int(order_type), comment)
+    return jsonify(result), 201
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -21,7 +21,14 @@ def connect():
     if not (login and password and server):
         return jsonify({"error": "login, password and server are required"}), 400
 
-    client = MT5Client(int(login), password, server)
+    try:
+        login_id = int(login)
+    except (ValueError, TypeError):
+        return jsonify({"error": "login must be a valid integer"}), 400
+
+    if client:
+        client.shutdown()
+    client = MT5Client(login_id, password, server)
     if not client.connect():
         return jsonify({"error": "failed to connect"}), 500
     return jsonify({"status": "connected"})

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -47,7 +47,10 @@ def place_order():
     if not (symbol and volume and order_type is not None):
         return jsonify({"error": "symbol, volume and type are required"}), 400
 
-    result = client.send_market_order(symbol, float(volume), int(order_type), comment)
+    try:
+        result = client.send_market_order(symbol, float(volume), int(order_type), comment)
+    except (ValueError, TypeError):
+        return jsonify({"error": "volume and type must be valid numbers"}), 400
     return jsonify(result), 201
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=2.0
+MetaTrader5


### PR DESCRIPTION
## Summary
- add `MT5Client` wrapper around the MetaTrader5 Python package
- expose API endpoints to connect, fetch account info, and place orders
- document new endpoints and mention MT5 requirement
- include MetaTrader5 package in requirements

## Testing
- `python -m mcp_server.server` *(fails: `ModuleNotFoundError: No module named 'MetaTrader5'`)*

------
https://chatgpt.com/codex/tasks/task_e_68582d8805fc8324a93a8d4538ad1464