### PR TITLE
Implement initial MT5 integration framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MetaTrader5 MCP Server
+# MetaTrader5 AI Integration
 
-This repository provides a minimal template for building a MetaTrader 5 MCP server using Python and Flask. It demonstrates how to connect to a local MetaTrader 5 terminal and execute basic operations through simple REST APIs.
+This repository provides tools to integrate MetaTrader 5 terminals with AI applications. It includes a Python client library, a WebSocket MCP server, and a REST API based on FastAPI.
 
 ## Requirements
 
@@ -12,29 +12,16 @@ This repository provides a minimal template for building a MetaTrader 5 MCP serv
 
 ```bash
 pip install -r requirements.txt
-python -m mcp_server.server
 ```
 
-## Endpoints
+### MCP Server
 
-- `GET /api/v1/ping` – health check endpoint.
-- `POST /api/v1/connect` – initialize connection to MetaTrader 5.
-- `GET /api/v1/account` – fetch account information.
-- `POST /api/v1/orders` – send a market order using connected terminal.
+```bash
+python -m metatrader_mcp.cli serve --login <LOGIN> --password <PASS> --server <SERVER>
+```
 
-## 日本語での説明
+### OpenAPI Server
 
-このリポジトリは、Python と Flask を使用して MetaTrader 5 MCP サーバーを構築するための最小限のテンプレートです。ローカルの MetaTrader 5 ターミナルに接続し、簡潔な REST API を通じて基本的な操作を実行する方法を示しています。
-
-### 主な機能
-
-- `GET /api/v1/ping` – サーバーの稼働確認を行います。
-- `POST /api/v1/connect` – MetaTrader 5 への接続を初期化します。
-- `GET /api/v1/account` – 口座情報を取得します。
-- `POST /api/v1/orders` – 市場注文を送信します。
-
-### セットアップ方法
-
-1. `requirements.txt` に記載された依存パッケージをインストールします。
-2. `python -m mcp_server.server` を実行してサーバーを起動します。
-
+```bash
+uvicorn metatrader_openapi.main:app
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
 Flask>=2.0
+fastapi
+uvicorn
+websockets
+typer
+pydantic-settings
 MetaTrader5

--- a/src/metatrader_client/__init__.py
+++ b/src/metatrader_client/__init__.py
@@ -1,0 +1,5 @@
+"""High level client library for MetaTrader 5 integration."""
+
+from .client import MT5Client
+
+__all__ = ["MT5Client"]

--- a/src/metatrader_client/client.py
+++ b/src/metatrader_client/client.py
@@ -1,0 +1,32 @@
+"""Facade class providing access to MetaTrader 5 terminal features."""
+
+from __future__ import annotations
+
+from .client_connection import MT5Connection
+from .client_account import MT5Account
+from .client_market import MT5Market
+from .client_order import MT5Order
+from .client_history import MT5History
+
+
+class MT5Client:
+    """Entry point for interacting with MetaTrader 5 terminal."""
+
+    def __init__(self, login: int, password: str, server: str) -> None:
+        self._connection = MT5Connection(login, password, server)
+        self.account = MT5Account(self._connection)
+        self.market = MT5Market(self._connection)
+        self.order = MT5Order(self._connection)
+        self.history = MT5History(self._connection)
+
+    def connect(self) -> bool:
+        """Connect to the terminal using provided credentials."""
+        return self._connection.connect()
+
+    def disconnect(self) -> None:
+        """Disconnect from terminal."""
+        self._connection.disconnect()
+
+    @property
+    def connection(self) -> MT5Connection:
+        return self._connection

--- a/src/metatrader_client/client_account.py
+++ b/src/metatrader_client/client_account.py
@@ -1,0 +1,42 @@
+"""Account related helpers for MT5."""
+
+from __future__ import annotations
+
+from typing import Optional, Dict
+
+import MetaTrader5 as mt5
+
+from .client_connection import MT5Connection
+
+
+class MT5Account:
+    def __init__(self, connection: MT5Connection) -> None:
+        self._connection = connection
+
+    def get_account_info(self) -> Optional[Dict]:
+        info = mt5.account_info()
+        return info._asdict() if info else None
+
+    def get_balance(self) -> Optional[float]:
+        info = mt5.account_info()
+        return info.balance if info else None
+
+    def get_equity(self) -> Optional[float]:
+        info = mt5.account_info()
+        return info.equity if info else None
+
+    def get_margin(self) -> Optional[float]:
+        info = mt5.account_info()
+        return info.margin if info else None
+
+    def get_free_margin(self) -> Optional[float]:
+        info = mt5.account_info()
+        return info.margin_free if info else None
+
+    def get_margin_level(self) -> Optional[float]:
+        info = mt5.account_info()
+        return info.margin_level if info else None
+
+    def is_trade_allowed(self) -> Optional[bool]:
+        info = mt5.account_info()
+        return info.trade_allowed if info else None

--- a/src/metatrader_client/client_connection.py
+++ b/src/metatrader_client/client_connection.py
@@ -1,0 +1,41 @@
+"""Connection management for MetaTrader 5 terminal."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import MetaTrader5 as mt5
+
+from .exceptions import MT5ConnectionError
+
+
+class MT5Connection:
+    """Handle initialize and shutdown of MetaTrader 5 terminal."""
+
+    def __init__(self, login: int, password: str, server: str) -> None:
+        self.login = login
+        self.password = password
+        self.server = server
+        self._connected = False
+
+    def connect(self, timeout: int = 30) -> bool:
+        """Initialize connection to the terminal."""
+        self._connected = mt5.initialize(
+            login=self.login, password=self.password, server=self.server
+        )
+        if not self._connected:
+            raise MT5ConnectionError("failed to connect to terminal")
+        return True
+
+    def disconnect(self) -> None:
+        """Shutdown connection."""
+        if self._connected:
+            mt5.shutdown()
+            self._connected = False
+
+    def is_connected(self) -> bool:
+        return self._connected and mt5.terminal_info() is not None
+
+    def get_terminal_info(self) -> Optional[dict]:
+        info = mt5.terminal_info()
+        return info._asdict() if info else None

--- a/src/metatrader_client/client_history.py
+++ b/src/metatrader_client/client_history.py
@@ -1,0 +1,23 @@
+"""History retrieval helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Dict
+
+import MetaTrader5 as mt5
+
+from .client_connection import MT5Connection
+
+
+class MT5History:
+    def __init__(self, connection: MT5Connection) -> None:
+        self._connection = connection
+
+    def get_deals(self, from_date: datetime, to_date: datetime, symbol: str = "") -> List[Dict]:
+        deals = mt5.history_deals_get(from_date, to_date, group=symbol or None)
+        return [d._asdict() for d in deals] if deals else []
+
+    def get_orders(self, from_date: datetime, to_date: datetime, symbol: str = "") -> List[Dict]:
+        orders = mt5.history_orders_get(from_date, to_date, group=symbol or None)
+        return [o._asdict() for o in orders] if orders else []

--- a/src/metatrader_client/client_market.py
+++ b/src/metatrader_client/client_market.py
@@ -1,0 +1,37 @@
+"""Market data retrieval helpers."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Optional
+
+import MetaTrader5 as mt5
+
+from .client_connection import MT5Connection
+from .types import Timeframe
+
+
+class MT5Market:
+    def __init__(self, connection: MT5Connection) -> None:
+        self._connection = connection
+
+    def get_symbols(self) -> List[str]:
+        symbols = mt5.symbols_get()
+        return [s.name for s in symbols] if symbols else []
+
+    def get_symbol_info(self, symbol: str) -> Optional[Dict]:
+        info = mt5.symbol_info(symbol)
+        return info._asdict() if info else None
+
+    def get_symbol_price(self, symbol: str) -> Optional[Dict]:
+        tick = mt5.symbol_info_tick(symbol)
+        return tick._asdict() if tick else None
+
+    def get_candles_latest(self, symbol: str, timeframe: Timeframe, count: int) -> List[Dict]:
+        rates = mt5.copy_rates_from_pos(symbol, timeframe.value, 0, count)
+        return [r._asdict() for r in rates] if rates is not None else []
+
+    def get_candles_by_date(
+        self, symbol: str, timeframe: Timeframe, from_date, to_date
+    ) -> List[Dict]:
+        rates = mt5.copy_rates_range(symbol, timeframe.value, from_date, to_date)
+        return [r._asdict() for r in rates] if rates is not None else []

--- a/src/metatrader_client/client_order.py
+++ b/src/metatrader_client/client_order.py
@@ -1,0 +1,51 @@
+"""Trading operations for MetaTrader 5."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Optional
+
+import MetaTrader5 as mt5
+
+from .client_connection import MT5Connection
+from .types import OrderType
+
+
+class MT5Order:
+    def __init__(self, connection: MT5Connection) -> None:
+        self._connection = connection
+
+    def place_market_order(
+        self, symbol: str, volume: float, order_type: OrderType, comment: str = ""
+    ) -> Optional[Dict]:
+        request = {
+            "action": mt5.TRADE_ACTION_DEAL,
+            "symbol": symbol,
+            "volume": volume,
+            "type": order_type.value,
+            "comment": comment,
+            "type_time": mt5.ORDER_TIME_GTC,
+            "type_filling": mt5.ORDER_FILLING_IOC,
+        }
+        result = mt5.order_send(request)
+        return result._asdict() if result else None
+
+    def close_position(self, position_id: int, volume: float, order_type: OrderType) -> Optional[Dict]:
+        position = mt5.positions_get(ticket=position_id)
+        if not position:
+            return None
+        position = position[0]
+        request = {
+            "action": mt5.TRADE_ACTION_DEAL,
+            "position": position_id,
+            "symbol": position.symbol,
+            "volume": volume,
+            "type": order_type.value,
+            "type_time": mt5.ORDER_TIME_GTC,
+            "type_filling": mt5.ORDER_FILLING_IOC,
+        }
+        result = mt5.order_send(request)
+        return result._asdict() if result else None
+
+    def get_all_positions(self) -> List[Dict]:
+        positions = mt5.positions_get()
+        return [p._asdict() for p in positions] if positions else []

--- a/src/metatrader_client/exceptions.py
+++ b/src/metatrader_client/exceptions.py
@@ -1,0 +1,25 @@
+"""Custom exceptions for the MT5 client library."""
+
+
+class MT5Error(Exception):
+    """Base error for the library."""
+
+
+class MT5ConnectionError(MT5Error):
+    """Raised when connection to terminal fails."""
+
+
+class MT5TradeError(MT5Error):
+    """Raised on trading operation errors."""
+
+
+class MT5SymbolError(MT5Error):
+    """Symbol not found or invalid."""
+
+
+class MT5TimeframeError(MT5Error):
+    """Invalid timeframe specified."""
+
+
+class MT5NotConnectedError(MT5Error):
+    """Operation attempted without active connection."""

--- a/src/metatrader_client/types/__init__.py
+++ b/src/metatrader_client/types/__init__.py
@@ -1,0 +1,24 @@
+"""Enum definitions mirroring MetaTrader5 constants."""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class Timeframe(IntEnum):
+    M1 = 1
+    M5 = 5
+    M15 = 15
+    M30 = 30
+    H1 = 60
+    H4 = 240
+    D1 = 1440
+
+
+class OrderType(IntEnum):
+    BUY = 0
+    SELL = 1
+    BUY_LIMIT = 2
+    SELL_LIMIT = 3
+    BUY_STOP = 4
+    SELL_STOP = 5

--- a/src/metatrader_mcp/__init__.py
+++ b/src/metatrader_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP server exposing MT5 client as tools."""

--- a/src/metatrader_mcp/cli.py
+++ b/src/metatrader_mcp/cli.py
@@ -1,0 +1,35 @@
+"""Command line interface to run MCP server."""
+
+import asyncio
+from typing import Optional
+
+import typer
+
+from metatrader_client import MT5Client
+from .server import MCPServer
+
+app = typer.Typer()
+
+
+@app.command()
+def serve(
+    host: str = "127.0.0.1",
+    port: int = 8765,
+    login: int = typer.Option(...),
+    password: str = typer.Option(...),
+    server: str = typer.Option(...),
+):
+    """Start MCP server."""
+    client = MT5Client(login, password, server)
+    client.connect()
+    server_obj = MCPServer(host, port, client)
+
+    # register simple tools using docstrings
+    server_obj.register_tool("account_info", client.account.get_account_info, "Return account info")
+    server_obj.register_tool("positions", client.order.get_all_positions, "Return open positions")
+
+    asyncio.run(server_obj.run())
+
+
+if __name__ == "__main__":
+    app()

--- a/src/metatrader_mcp/server.py
+++ b/src/metatrader_mcp/server.py
@@ -1,0 +1,44 @@
+"""WebSocket MCP server implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+import websockets
+
+from metatrader_client import MT5Client
+
+
+@dataclass
+class Tool:
+    func: Callable
+    description: str
+
+
+class MCPServer:
+    def __init__(self, host: str, port: int, client: MT5Client) -> None:
+        self.host = host
+        self.port = port
+        self.client = client
+        self.tools: Dict[str, Tool] = {}
+
+    def register_tool(self, name: str, func: Callable, description: str) -> None:
+        self.tools[name] = Tool(func, description)
+
+    async def handler(self, websocket):
+        async for message in websocket:
+            data = json.loads(message)
+            name = data.get("tool")
+            args = data.get("args", {})
+            if name not in self.tools:
+                await websocket.send(json.dumps({"error": "unknown tool"}))
+                continue
+            result = self.tools[name].func(**args)
+            await websocket.send(json.dumps({"result": result}))
+
+    async def run(self):
+        async with websockets.serve(self.handler, self.host, self.port):
+            await asyncio.Future()  # run forever

--- a/src/metatrader_openapi/__init__.py
+++ b/src/metatrader_openapi/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP API for MetaTrader 5 integration."""

--- a/src/metatrader_openapi/config.py
+++ b/src/metatrader_openapi/config.py
@@ -1,0 +1,12 @@
+"""Application configuration using environment variables."""
+
+from pydantic_settings import BaseSettings
+
+
+class MT5Config(BaseSettings):
+    login: int
+    password: str
+    server: str
+
+    class Config:
+        env_prefix = "MT5_"

--- a/src/metatrader_openapi/main.py
+++ b/src/metatrader_openapi/main.py
@@ -1,0 +1,23 @@
+"""FastAPI server exposing REST endpoints."""
+
+from fastapi import Depends, FastAPI
+
+from metatrader_client import MT5Client
+from .config import MT5Config
+from .routers import accounts, market, orders, positions, history
+
+app = FastAPI(title="MetaTrader OpenAPI")
+
+
+def get_client() -> MT5Client:
+    config = MT5Config()
+    client = MT5Client(config.login, config.password, config.server)
+    client.connect()
+    return client
+
+
+app.include_router(accounts.router, dependencies=[Depends(get_client)])
+app.include_router(market.router, dependencies=[Depends(get_client)])
+app.include_router(orders.router, dependencies=[Depends(get_client)])
+app.include_router(positions.router, dependencies=[Depends(get_client)])
+app.include_router(history.router, dependencies=[Depends(get_client)])

--- a/src/metatrader_openapi/routers/__init__.py
+++ b/src/metatrader_openapi/routers/__init__.py
@@ -1,0 +1,3 @@
+from . import accounts, market, orders, positions, history
+
+__all__ = ["accounts", "market", "orders", "positions", "history"]

--- a/src/metatrader_openapi/routers/accounts.py
+++ b/src/metatrader_openapi/routers/accounts.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends
+
+from metatrader_client import MT5Client
+
+router = APIRouter(prefix="/api/v1/accounts", tags=["accounts"])
+
+
+def get_client(client: MT5Client = Depends()):
+    return client
+
+
+@router.get("/info")
+def account_info(client: MT5Client = Depends(get_client)):
+    return client.account.get_account_info()

--- a/src/metatrader_openapi/routers/history.py
+++ b/src/metatrader_openapi/routers/history.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+
+from metatrader_client import MT5Client
+
+router = APIRouter(prefix="/api/v1/history", tags=["history"])
+
+
+def get_client(client: MT5Client = Depends()):
+    return client
+
+
+@router.get("/deals")
+def deals(from_date: datetime, to_date: datetime, client: MT5Client = Depends(get_client)):
+    return client.history.get_deals(from_date, to_date)
+
+
+@router.get("/orders")
+def orders(from_date: datetime, to_date: datetime, client: MT5Client = Depends(get_client)):
+    return client.history.get_orders(from_date, to_date)

--- a/src/metatrader_openapi/routers/market.py
+++ b/src/metatrader_openapi/routers/market.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends
+
+from metatrader_client import MT5Client
+
+router = APIRouter(prefix="/api/v1/market", tags=["market"])
+
+
+def get_client(client: MT5Client = Depends()):
+    return client
+
+
+@router.get("/symbols")
+def symbols(client: MT5Client = Depends(get_client)):
+    return client.market.get_symbols()

--- a/src/metatrader_openapi/routers/orders.py
+++ b/src/metatrader_openapi/routers/orders.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+
+from metatrader_client import MT5Client
+from metatrader_client.types import OrderType
+
+router = APIRouter(prefix="/api/v1/orders", tags=["orders"])
+
+
+def get_client(client: MT5Client = Depends()):
+    return client
+
+
+@router.post("/market")
+def market_order(symbol: str, volume: float, order_type: OrderType, client: MT5Client = Depends(get_client)):
+    return client.order.place_market_order(symbol, volume, order_type)

--- a/src/metatrader_openapi/routers/positions.py
+++ b/src/metatrader_openapi/routers/positions.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends
+
+from metatrader_client import MT5Client
+
+router = APIRouter(prefix="/api/v1/positions", tags=["positions"])
+
+
+def get_client(client: MT5Client = Depends()):
+    return client
+
+
+@router.get("")
+def all_positions(client: MT5Client = Depends(get_client)):
+    return client.order.get_all_positions()


### PR DESCRIPTION
## Summary
- implement MT5 client library with connection, account, market, order and history helpers
- add MCP WebSocket server and CLI
- add FastAPI-based OpenAPI server with routers
- update requirements and README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement MetaTrader5)*

------
https://chatgpt.com/codex/tasks/task_e_68590b9392748324aaf5495bc92e0553