### PR TITLE
Add Japanese section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,31 @@ python -m metatrader_mcp.cli serve --login <LOGIN> --password <PASS> --server <S
 ```bash
 uvicorn metatrader_openapi.main:app
 ```
+
+## 日本語
+
+このリポジトリは MetaTrader 5 ターミナルを AI アプリケーションと統合するためのツールを提供します。Python クライアントライブラリ、WebSocket MCP サーバー、FastAPI ベースの REST API を含みます。
+
+### 必要条件
+
+- Python 3.12 以上
+- `requirements.txt` に記載された依存関係
+- 実行中の MetaTrader 5 ターミナル
+
+### セットアップ
+
+```bash
+pip install -r requirements.txt
+```
+
+#### MCP サーバー
+
+```bash
+python -m metatrader_mcp.cli serve --login <LOGIN> --password <PASS> --server <SERVER>
+```
+
+#### OpenAPI サーバー
+
+```bash
+uvicorn metatrader_openapi.main:app
+```


### PR DESCRIPTION
## Summary
- add a Japanese translation to README so documentation is bilingual

## Testing
- `pip install -r requirements.txt` *(fails: no matching distribution for MetaTrader5)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685954c551048324a77e48ecdf96a250